### PR TITLE
FEAT: Window Scroll 時にハイライトボタンを閉じるようにした

### DIFF
--- a/apps/browser/src/contents/hooks/usePopover.ts
+++ b/apps/browser/src/contents/hooks/usePopover.ts
@@ -1,9 +1,15 @@
-import { useMemo, useState } from "react";
-import { useEvent } from "react-use";
+import { useEffect, useMemo, useState } from "react";
+import { useEvent, useWindowScroll } from "react-use";
 
 export const usePopover = () => {
   const [open, setOpen] = useState(false);
   const [pos, setPos] = useState({ x: 0, y: 0 });
+
+  const scroll = useWindowScroll();
+
+  useEffect(() => {
+    setOpen(false);
+  }, [scroll]);
 
   const onMouseUp = (event: React.MouseEvent) => {
     const selection = window.getSelection();


### PR DESCRIPTION
Close #41 

他のアプリにならってハイライト用のポップオーバーが出ている間にスクロールされたら、ポップオーバーを隠すようにした